### PR TITLE
Remove homebrew hint

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -85,7 +85,7 @@
 				<key>scriptfile</key>
 				<string>basecalc.lua</string>
 				<key>subtext</key>
-				<string>Enter a Lua numeric expression (hint: brew install lua)</string>
+				<string>Enter a Lua numeric expression</string>
 				<key>title</key>
 				<string>Programmers calculator</string>
 				<key>type</key>


### PR DESCRIPTION
You mention the dependency in the README, and in the Gallery it’ll be prominent:

<img width="867" alt="image" src="https://user-images.githubusercontent.com/1699443/209997311-fafe9ca3-0f35-4b1b-91b0-c24bd2530c53.png">

Alfred can then [help to install lua via Homebrew](https://www.alfredapp.com/help/kb/dependencies/).